### PR TITLE
Fix types for v3

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module "emotion-reset" {
-  import { SerializedStyles } from "@emotion/core";
+  import { SerializedStyles } from "@emotion/react";
   const reset: SerializedStyles;
   export default reset;
 }


### PR DESCRIPTION
We encountered a bug in our project where some Emotion types started acting weird. After some hours of debugging, it turns out this typing file is the cause of our problems. It seems like it's still referencing the old `@emotion/core` package (and Storybook relies on this internally, so we ended up having this in our `node_modules`).

I've updated the type to reference `@emotion/react` instead.